### PR TITLE
Update is-porn.js

### DIFF
--- a/lib/is-porn.js
+++ b/lib/is-porn.js
@@ -2,8 +2,8 @@
 const nslookup = require('nslookup');
 const debug = require('debug')('is-porn');
 const OPENDNS_IPS = [
-    /67\.215\.65.\d{3}/gi,
-    /146\.112\.61\.\d{3}/gi,
+    /67\.215\.65.\d{3}/i,
+    /146\.112\.61\.\d{3}/i,
 ];
 
 var isOpenDNS = function(ip) {


### PR DESCRIPTION
closes #3 

The issue is due to the use of the test() method on a RegExp object with the g (global) flag. When the test() method is used with a global regular expression, the lastIndex property of the RegExp object is automatically updated to point to the position in the string where the next match will start. This means that subsequent calls to test() will start from this position, leading to unexpected results.

It is also possible to fix this
```
const isOpenDNS = function(ip) {
                return OPENDNS_IPS.some(function(regexp) {
                    debug('trying', regexp);
                    regexp.lastIndex = 0; // Reset lastIndex
                    return regexp.test(ip);
                });
            };
```